### PR TITLE
Diagnose: Backup card (ioBroker · NAS-Synology · InfluxDB-Dump)

### DIFF
--- a/deps/general/README.md
+++ b/deps/general/README.md
@@ -5,4 +5,13 @@ This is a place for general helper scripts to manage the raspberry.
 The backup script for the Raspberry PI is running on a Synology Diskstation.
 1. Add `authorized_keys` on raspberry (see, e.g., [How To Set Up Authorized Keys](https://wiki.qnap.com/wiki/SSH:_How_To_Set_Up_Authorized_Keys))
 2. The `backup_pi.sh` is scheduled as task on the Synology.
+3. `influx_backup.sh` runs nightly on the Pi (crontab `30 3 * * *`) so the NAS pull
+   captures a consistent InfluxDB dump instead of live data files.
+4. `export_backup_states.sh` bridges the two success markers
+   (`~/.last_nas_backup_success`, `~/influx_backup`) into ioBroker states so the
+   Diagnose tab's Backup card can show their age. Schedule it on the Pi:
+
+       */15 * * * * /home/pi/home-monitoring/deps/general/bin/export_backup_states.sh
+
+   Deploy `diagnose_v2.js` first — it creates the two states the script writes to.
 

--- a/deps/general/bin/export_backup_states.sh
+++ b/deps/general/bin/export_backup_states.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Publish backup freshness into ioBroker states for the Diagnose tab's Backup card.
+#
+# The dashboard runs inside ioBroker and cannot see the filesystem, so this
+# bridges the two on-disk markers into javascript.0.* states (created by
+# diagnose_v2.js — deploy that script before scheduling this one):
+#   /home/pi/.last_nas_backup_success  touched by backup_pi.sh after a NAS pull
+#   /home/pi/influx_backup             replaced atomically by influx_backup.sh
+#
+# Run on the ioBroker host via cron, e.g.:
+#   */15 * * * * /home/pi/home-monitoring/deps/general/bin/export_backup_states.sh
+set -euo pipefail
+
+mtime() { stat -c %Y "$1" 2>/dev/null || echo 0; }
+
+iobroker state set javascript.0.backup_nas_ts "$(mtime /home/pi/.last_nas_backup_success)" true >/dev/null
+iobroker state set javascript.0.backup_influx_ts "$(mtime /home/pi/influx_backup)" true >/dev/null

--- a/integrations/iobroker/diagnose_v2.js
+++ b/integrations/iobroker/diagnose_v2.js
@@ -4,7 +4,7 @@
 //
 //   diag_summary (4,4)   1170x72  — overall verdict + Stand
 //   diag_left    (4,84)   392x596 — DATENQUELLEN: per-source age + freshness verdict (primary)
-//   diag_mid     (408,84) 377x596 — SYSTEM · Pi: CPU / Last / RAM / Disk / Uptime
+//   diag_mid     (408,84) 377x596 — SYSTEM · Pi: CPU / Last / RAM / Disk / Uptime + BACKUP card
 //   diag_right   (797,84) 377x596 — ADAPTER: alive/connected dots
 
 var CSS_BASE = `
@@ -52,6 +52,11 @@ var CSS_BASE = `
 .mv2 .track{height:7px; border-radius:4px; background:var(--inset); overflow:hidden}
 .mv2 .fill{height:7px; border-radius:4px; min-width:3px; display:block}
 .mv2 .srow.plain{display:flex; align-items:baseline; justify-content:space-between}
+
+/* mid column stacks two cards (System · Pi fills, Backup keeps its natural height) */
+.mv2 .mcol{height:100%; display:flex; flex-direction:column; gap:8px}
+.mv2 .mcol .card{height:auto}
+.mv2 .mcol .card.grow{flex:1}
 `;
 
 var GREEN = '#b5fb5b', AMBER = '#F1BE3D', BLUE = '#5080AC', RED = '#A00629', LBL = '#8A8A8A', TEXT = '#CCCCCC';
@@ -160,12 +165,45 @@ function buildSystem() {
     var diskCol = diskGB == null ? LBL : (diskGB > 3 ? GREEN : diskGB > 1 ? AMBER : RED);
     var upTxt = up == null ? '–' : (up < 86400 ? Math.round(up / 3600) + ' h' : Math.round(up / 86400) + ' d');
 
-    var h = '<div class="card"><div class="card-h">System · Pi</div><div class="sys">';
+    var h = '<div class="card grow"><div class="card-h">System · Pi</div><div class="sys">';
     h += '<div class="srow"><div class="top"><span class="l">CPU</span><span class="v" style="color:' + cpuCol + '">' + (cpu != null ? Math.round(cpu) : '–') + '<span class="u">%</span></span></div>' + bar((cpu || 0) / 100, cpuCol) + '</div>';
     h += '<div class="srow plain"><span class="l">Last (1 min)</span><span class="v" style="color:' + loadCol + '">' + comma(load, 2) + '</span></div>';
     h += '<div class="srow plain"><span class="l">RAM frei</span><span class="v" style="color:' + memCol + '">' + (freeGB != null ? comma(freeGB, 1) : '–') + '<span class="u">GB</span></span></div>';
     h += '<div class="srow plain"><span class="l">Disk frei</span><span class="v" style="color:' + diskCol + '">' + (diskGB != null ? comma(diskGB, 1) : '–') + '<span class="u">GB</span></span></div>';
     h += '<div class="srow plain"><span class="l">Uptime</span><span class="v">' + upTxt + '</span></div>';
+    return h + '</div></div>';
+}
+
+// ===== BACKUP =====
+// One row per backup in the chain: the backitup app backup (its own states), and the two
+// filesystem markers bridged into states by deps/general/bin/export_backup_states.sh.
+// Thresholds follow conf/healthcheck.json (SLA 1560 min): green within 26 h, amber to 48 h.
+var BK_FRESH = 26 * 3600, BK_AMBER = 48 * 3600;
+function epochAge(id) {
+    var s = getState(id);
+    var ts = s && s.val != null ? Number(s.val) : 0;    // exporter may write it as a string
+    return ts > 0 ? Math.max(0, Math.round(Date.now() / 1000 - ts)) : null;
+}
+function backupRows() {
+    var rows = [];
+    var last = null;
+    try { last = JSON.parse(getState('backitup.0.history.json').val)[0]; } catch (e) { /* no history yet */ }
+    var age = last && last.timestamp ? Math.max(0, Math.round((Date.now() - last.timestamp) / 1000)) : null;
+    var failed = !!(last && last.error && last.error !== 'none');
+    rows.push({ nm: 'ioBroker', txt: failed ? 'Fehler' : fmtAge(age), col: failed ? RED : freshCol(age, BK_FRESH, BK_AMBER) });
+    [['NAS · Synology', 'javascript.0.backup_nas_ts'], ['InfluxDB-Dump', 'javascript.0.backup_influx_ts']].forEach(function (b) {
+        var a = epochAge(b[1]);
+        rows.push({ nm: b[0], txt: a == null ? 'nie' : fmtAge(a), col: freshCol(a, BK_FRESH, BK_AMBER) });
+    });
+    return rows;
+}
+function buildBackup() {
+    var h = '<div class="card"><div class="card-h">Backup</div><div class="rows">';
+    backupRows().forEach(function (r) {
+        h += '<div class="drow">' + dot(r.col)
+            + '<span class="nm">' + esc(r.nm) + '</span>'
+            + '<span class="ag" style="color:' + r.col + '">' + r.txt + '</span></div>';
+    });
     return h + '</div></div>';
 }
 
@@ -184,13 +222,16 @@ function buildAdapters() {
 function publish() {
     setState('diag_summary', fo('sumw', 1170, 72, buildSummary()), true);
     setState('diag_left', fo('dlw', 392, 596, buildSources()), true);
-    setState('diag_mid', fo('dmw', 377, 596, buildSystem()), true);
+    setState('diag_mid', fo('dmw', 377, 596, '<div class="mcol">' + buildSystem() + buildBackup() + '</div>'), true);
     setState('diag_right', fo('drw', 377, 596, buildAdapters()), true);
 }
 
 ['diag_summary', 'diag_left', 'diag_mid', 'diag_right'].forEach(function (id) {
     createState('javascript.0.' + id, '', { type: 'string', role: 'html', desc: 'Diagnose tab ' + id });
 });
+// filesystem backup markers (epoch seconds), written by deps/general/bin/export_backup_states.sh
+createState('javascript.0.backup_nas_ts', 0, { type: 'number', role: 'value.time', desc: 'NAS-Pull Erfolgs-Marker' });
+createState('javascript.0.backup_influx_ts', 0, { type: 'number', role: 'value.time', desc: 'Influx-Dump Marker' });
 
 // freshness is time-based — refresh every minute (also catches adapter/host changes)
 setTimeout(publish, 2000);

--- a/openspec/changes/harden-backup-and-recovery/tasks.md
+++ b/openspec/changes/harden-backup-and-recovery/tasks.md
@@ -6,8 +6,11 @@
       and the `/home/pi/.last_nas_backup_success` marker, SLAs in conf (26 h each)
 - [x] 1.2 Telegram alert + recovery notice (reuses notifier/dedup); 4 tests.
       Deployed + verified live on the Pi (both backups evaluated fresh, sent=0)
-- [ ] 1.3 Dashboard tile "Letztes Backup" — DEFERRED (Telegram alerting already
-      delivers the visibility; tile is nice-to-have, needs a state-export path)
+- [x] 1.3 Dashboard tile "Letztes Backup" — DONE (2026-07-04, owner request): Backup card
+      on the Diagnose tab (diagnose_v2.js, mid column under System · Pi) with three rows —
+      ioBroker (backitup.0.history.json), NAS · Synology and InfluxDB-Dump (marker mtimes
+      bridged into javascript.0.backup_{nas,influx}_ts by deps/general/bin/export_backup_states.sh,
+      cron */15). Thresholds mirror the healthcheck SLA: green ≤26 h, amber ≤48 h, red beyond/never.
 
 ## 2. Consistent DB dump + improved backup script (#2, #3, #7) — DONE
 


### PR DESCRIPTION
Un-defers task 1.3 of `harden-backup-and-recovery` (owner request): backup freshness on the Diagnose tab.

- **Backup card** under System · Pi (mid column): one verdict row per backup in the chain — ioBroker straight from `backitup.0.history.json` (age, `Fehler` on error), NAS · Synology and InfluxDB-Dump from marker mtimes. Thresholds mirror the healthcheck SLA: green ≤26 h, amber ≤48 h, red beyond / `nie`.
- **`deps/general/bin/export_backup_states.sh`**: the state-export path the deferred tile was waiting for — bridges the two filesystem markers into `javascript.0.backup_{nas,influx}_ts` (Pi cron `*/15`, documented in the README; deploy `diagnose_v2.js` first, it creates the states).

Render-verified incl. edge cases (missing states → `nie`, backitup error → `Fehler`, string timestamps parse). **Not yet deployed** — needs the cron line, and `diagnose_v2.js` is also touched (different hunks) by #klima-studio.

⚠️ Real finding while building this: `/home/pi/.last_nas_backup_success` is stale since **2026-06-11** — the Synology-side `backup_pi.sh` task has likely never succeeded since setup. Check the DSM task scheduler; the card will show it red until it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a backup status card to the Diagnose dashboard and wire it to filesystem-based backup markers exported into ioBroker states.

New Features:
- Introduce a Backup card on the Diagnose tab showing freshness of ioBroker, NAS, and InfluxDB backups with SLA-based color coding.

Enhancements:
- Extend the System · Pi column layout to stack the existing system card with the new backup card.
- Create dedicated ioBroker states to hold NAS and InfluxDB backup timestamps for dashboard consumption.
- Document backup and state-export scheduling in the general helpers README and mark the backup dashboard task as completed in the backup-hardening spec.

Build:
- Add a cron-driven helper script to export NAS and InfluxDB backup marker mtimes into ioBroker states for the Diagnose dashboard.