### PR TITLE
docs: correct Pi path in backup-cron instructions

### DIFF
--- a/deps/general/README.md
+++ b/deps/general/README.md
@@ -11,7 +11,7 @@ The backup script for the Raspberry PI is running on a Synology Diskstation.
    (`~/.last_nas_backup_success`, `~/influx_backup`) into ioBroker states so the
    Diagnose tab's Backup card can show their age. Schedule it on the Pi:
 
-       */15 * * * * /home/pi/home-monitoring/deps/general/bin/export_backup_states.sh
+       */15 * * * * /home/pi/src/github.com/BigCrunsh/home-monitoring/deps/general/bin/export_backup_states.sh
 
    Deploy `diagnose_v2.js` first — it creates the two states the script writes to.
 


### PR DESCRIPTION
One-line fix: the README's cron example pointed at /home/pi/home-monitoring; the Pi checkout actually lives at /home/pi/src/github.com/BigCrunsh/home-monitoring (same path the influx_backup.sh cron uses). The crontab installed on the Pi already uses the correct path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Fix the Raspberry Pi backup cron example path in the README to match the actual home-monitoring directory layout.