### PR TITLE
fix(backup): NAS pull failed nightly — dump-swap collision + fatal warning exits

### DIFF
--- a/deps/general/README.md
+++ b/deps/general/README.md
@@ -5,8 +5,11 @@ This is a place for general helper scripts to manage the raspberry.
 The backup script for the Raspberry PI is running on a Synology Diskstation.
 1. Add `authorized_keys` on raspberry (see, e.g., [How To Set Up Authorized Keys](https://wiki.qnap.com/wiki/SSH:_How_To_Set_Up_Authorized_Keys))
 2. The `backup_pi.sh` is scheduled as task on the Synology.
-3. `influx_backup.sh` runs nightly on the Pi (crontab `30 3 * * *`) so the NAS pull
-   captures a consistent InfluxDB dump instead of live data files.
+3. `influx_backup.sh` runs nightly on the Pi (crontab `15 2 * * *`) so the NAS pull
+   captures a consistent InfluxDB dump instead of live data files. It must finish
+   before the NAS pull starts (03:00) — a dump swap mid-transfer makes rsync exit 24
+   (files vanished) every night, which is exactly what broke the backups in June/July 2026.
+   After changing `backup_pi.sh`, copy it to the NAS task location (`/volume1/rpi_backup/scripts/`).
 4. `export_backup_states.sh` bridges the two success markers
    (`~/.last_nas_backup_success`, `~/influx_backup`) into ioBroker states so the
    Diagnose tab's Backup card can show their age. Schedule it on the Pi:

--- a/deps/general/bin/backup_pi.sh
+++ b/deps/general/bin/backup_pi.sh
@@ -59,11 +59,18 @@ rsync \
     "$DEST.partial" >> "$LOGFILE" 2>&1
 
 error_code=$?
-if [ "$error_code" -ne 0 ]; then
+# 24 = source files vanished during the transfer, 23 = partial transfer (a few
+# attr/read errors) — both are normal when pulling a LIVE rootfs and still leave
+# a usable snapshot. Only harder failures discard the night's work.
+if [ "$error_code" -ne 0 ] && [ "$error_code" -ne 23 ] && [ "$error_code" -ne 24 ]; then
     log "$error_code: rsync failed; keeping existing snapshots"
     rm -rf "$DEST.partial"
+    # leave the exit code on the Pi so the failure is debuggable from there
+    ssh -p 22 "$USER@$RASPBERRY_PI" "echo $error_code > /home/pi/.last_nas_backup_error" \
+        >> "$LOGFILE" 2>&1 || true
     exit 1
 fi
+[ "$error_code" -ne 0 ] && log "warning: rsync exit $error_code (tolerated, snapshot kept)"
 
 # Promote the partial snapshot atomically and repoint 'latest'
 rm -rf "$DEST"
@@ -80,7 +87,7 @@ ls -1d "$SERVERDIR"/20*-*-* 2>/dev/null | sort | head -n "-$KEEP" | while read -
 done
 
 # Touch a success marker on the Pi for the freshness healthcheck
-ssh -p 22 "$USER@$RASPBERRY_PI" 'touch /home/pi/.last_nas_backup_success' \
+ssh -p 22 "$USER@$RASPBERRY_PI" 'touch /home/pi/.last_nas_backup_success && rm -f /home/pi/.last_nas_backup_error' \
     >> "$LOGFILE" 2>&1 || log "warning: could not touch success marker on Pi"
 
 log "Done"


### PR DESCRIPTION
Debugging the red **NAS · Synology** row on the new Diagnose Backup card (stale since 2026-06-11) from the Pi side:

- The DSM task **does run nightly**: sshd shows the NAS (192.168.178.51) opening the rsync session 03:00:04 and closing ~03:40 — a full pass, every night.
- The success-marker touch (a second ssh) never follows → the script exits through its failure branch.
- **Root cause**: `influx_backup.sh` (cron 03:30) atomically swaps its ~63-file dump directory **in the middle of the 03:00–03:40 pull window** → rsync sees vanished files → exit 24 → `backup_pi.sh` treats any nonzero exit as fatal and deletes the night's `.partial`.

Fixes:
- `backup_pi.sh`: tolerate rsync exits 23/24 (usable snapshot, logged as warning); on hard failure, leave the exit code in `/home/pi/.last_nas_backup_error`; success clears it.
- Pi crontab: influx dump moved 03:30 → **02:15** (done on the Pi; README updated).

**Manual step required**: copy the updated `backup_pi.sh` to the NAS task location (`/volume1/rpi_backup/scripts/`) — no NAS shell access from here. The cron move alone should already turn the card green tomorrow (~03:45).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Relax NAS backup rsync error handling to treat transient file-vanished/partial-transfer exits as acceptable while improving observability of hard failures, and document the adjusted InfluxDB dump schedule and deployment steps for the backup script.

Bug Fixes:
- Allow rsync exits 23 and 24 to be treated as non-fatal so nightly NAS pulls still keep usable snapshots when files vanish mid-transfer.
- Record the last nonzero rsync exit code on the Pi and clear it on successful runs to aid diagnosing backup failures.

Documentation:
- Update backup README to move the InfluxDB dump cron to 02:15, explain the timing dependency with the NAS pull, and note the need to redeploy the updated backup script to the NAS.